### PR TITLE
Fixed bug #9: Return correct number of results for Booster.PredictType.Contrib

### DIFF
--- a/LightGBMNet.Train/Interface/Booster.cs
+++ b/LightGBMNet.Train/Interface/Booster.cs
@@ -445,7 +445,8 @@ namespace LightGBMNet.Train
             if (predictType == PredictType.LeafIndex)
                     throw new NotImplementedException("TODO: PredictType.LeafIndex");
 
-            long outLen = NumClasses; // TODO
+            int numRow = 1; // Only 1 mat
+            long outLen = CalcNumPredict(numRow, predictType, numIteration);
             double[] outResult = new double[outLen];
             fixed (double* ptr = outResult)
                 PInvokeException.Check(PInvoke.BoosterPredictForMat( Handle


### PR DESCRIPTION
Calculate the number of expected results before allocation the output buffer.